### PR TITLE
Add part number to the device types in initial data design

### DIFF
--- a/jobs/initial_data/designs/0001_design.yaml.j2
+++ b/jobs/initial_data/designs/0001_design.yaml.j2
@@ -14,8 +14,10 @@ platforms:
 device_types:
   - "!create_or_update:model": "PTX10016"
     manufacturer__name: "Juniper"
+    part_number: "PTX10016-PREM2"
     u_height: 21
   - "!create_or_update:model": "C8300-1N1S-6T"
+    part_number: "C8300-1N1S-6T"
     manufacturer__name: "Cisco"
     u_height: 1
 


### PR DESCRIPTION
Add part number to the device types in initial data design. This will make this design compliant with the Nautobot Solitaire regex validation rules for the device type.